### PR TITLE
Add assertions to detect programming errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,4 +58,5 @@ checkstyle {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }

--- a/src/main/java/sky/command/DeadlineCommand.java
+++ b/src/main/java/sky/command/DeadlineCommand.java
@@ -28,6 +28,7 @@ public class DeadlineCommand extends Command {
         try {
             String taskDeadline = this.fullCommand.substring(9);
             String[] arrOfStrings = taskDeadline.split(" /by ");
+            assert arrOfStrings.length > 0 : "arrOfStrings should not be empty.";
             if (arrOfStrings.length != 2) {
                 throw new TextNoMeaningException("Make sure you specify \"/by\" exactly once,"
                         + " and follow it up with a date and time as: \"yyyy/mm/dd XXXX\","

--- a/src/main/java/sky/command/DeleteCommand.java
+++ b/src/main/java/sky/command/DeleteCommand.java
@@ -23,6 +23,8 @@ public class DeleteCommand extends Command {
             String taskNumInString = this.fullCommand.substring(7);
             // Minus one as arrayList is zero-indexed
             int taskNum = Integer.parseInt(taskNumInString) - 1;
+            assert taskNum >= 0 : "taskNum should not be a negative number as it is used for"
+                    + " array-indexing purposes.";
             Task task = taskList.getTask(taskNum);
             taskList.removeTask(task);
             storage.reWriteDataFile(taskList);

--- a/src/main/java/sky/command/EventCommand.java
+++ b/src/main/java/sky/command/EventCommand.java
@@ -29,6 +29,7 @@ public class EventCommand extends Command {
         try {
             String taskEvent = this.fullCommand.substring(6);
             String[] arrOfStrings = taskEvent.split(" /at ");
+            assert arrOfStrings.length > 0 : "arrOfStrings should not be empty.";
             if (arrOfStrings.length != 2) {
                 throw new TextNoMeaningException("Make sure you specify \"/at\" exactly once,"
                         + " and follow it up with a date and time as: \"yyyy/mm/dd XXXX-XXXX\","

--- a/src/main/java/sky/command/MarkCommand.java
+++ b/src/main/java/sky/command/MarkCommand.java
@@ -23,6 +23,8 @@ public class MarkCommand extends Command {
             String taskNumInString = this.fullCommand.substring(5);
             // Minus one as arrayList is zero-indexed
             int taskNum = Integer.parseInt(taskNumInString) - 1;
+            assert taskNum >= 0 : "taskNum should not be a negative number as it is used for"
+                    + " array-indexing purposes.";
             Task task = taskList.getTask(taskNum);
             task.markAsDone();
             storage.reWriteDataFile(taskList);

--- a/src/main/java/sky/command/UnmarkCommand.java
+++ b/src/main/java/sky/command/UnmarkCommand.java
@@ -23,6 +23,8 @@ public class UnmarkCommand extends Command {
             String taskNumInString = this.fullCommand.substring(7);
             // Minus one as arrayList is zero-indexed
             int taskNum = Integer.parseInt(taskNumInString) - 1;
+            assert taskNum >= 0 : "taskNum should not be a negative number as it is used for"
+                    + " array-indexing purposes.";
             Task task = taskList.getTask(taskNum);
             task.markAsUndone();
             storage.reWriteDataFile(taskList);


### PR DESCRIPTION
Currently, there are no assertions in the code base to detect
programming errors.

This needs to change as assertions can help to detect programming
errors early and prevent the chat bot from performing undesirably.

Add assertions to detect programming errors.

Assertions are not only simple, but their impact on performance is considered low and worth the additional safety they provide.